### PR TITLE
Add financial Autogen examples using local Ollama model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # Autogen_Agents
-Autogen_Agents
+
+This repository contains example use cases for [Autogen](https://github.com/microsoft/autogen) linked to a local model served by [Ollama](https://ollama.ai/). Each directory demonstrates a different financial industry scenario.
+
+## Available Use Cases
+
+- `credit_risk_assessment` – Credit Risk Assessment
+- `fraud_detection` – Fraud Detection
+- `customer_support` – Customer Support Chatbot
+- `regulatory_reporting` – Regulatory Reporting
+- `algorithmic_trading` – Algorithmic Trading Idea Generation
+- `portfolio_optimization` – Portfolio Optimization
+- `loan_underwriting` – Loan Underwriting
+- `compliance_monitoring` – Compliance Monitoring
+- `market_sentiment_analysis` – Market Sentiment Analysis
+- `data_extraction` – Financial Data Extraction
+
+Each folder includes a `README.md` and `main.py` script that illustrates how to configure Autogen to communicate with a locally hosted model.

--- a/algorithmic_trading/README.md
+++ b/algorithmic_trading/README.md
@@ -1,0 +1,26 @@
+# Algorithmic Trading Idea Generation
+
+Generating a basic trading strategy.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/algorithmic_trading/main.py
+++ b/algorithmic_trading/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Provide a simple momentum trading strategy idea."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/compliance_monitoring/README.md
+++ b/compliance_monitoring/README.md
@@ -1,0 +1,26 @@
+# Compliance Monitoring
+
+Monitoring trades for compliance violations.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/compliance_monitoring/main.py
+++ b/compliance_monitoring/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Check trading logs for potential compliance issues."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/credit_risk_assessment/README.md
+++ b/credit_risk_assessment/README.md
@@ -1,0 +1,26 @@
+# Credit Risk Assessment
+
+Assessing credit risk for a hypothetical borrower.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/credit_risk_assessment/main.py
+++ b/credit_risk_assessment/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Evaluate credit risk for a sample loan applicant."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/customer_support/README.md
+++ b/customer_support/README.md
@@ -1,0 +1,26 @@
+# Customer Support Chatbot
+
+Answering customer questions automatically.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/customer_support/main.py
+++ b/customer_support/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Answer common customer questions about account features."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/data_extraction/README.md
+++ b/data_extraction/README.md
@@ -1,0 +1,26 @@
+# Financial Data Extraction
+
+Extracting metrics from financial text.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/data_extraction/main.py
+++ b/data_extraction/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Extract key financial metrics from the given statement."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/fraud_detection/README.md
+++ b/fraud_detection/README.md
@@ -1,0 +1,26 @@
+# Fraud Detection
+
+Finding suspicious transactions from sample data.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/fraud_detection/main.py
+++ b/fraud_detection/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Identify potential fraud in a list of sample transactions."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/loan_underwriting/README.md
+++ b/loan_underwriting/README.md
@@ -1,0 +1,26 @@
+# Loan Underwriting
+
+Underwriting a sample loan application.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/loan_underwriting/main.py
+++ b/loan_underwriting/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Assess a loan application and provide underwriting notes."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/market_sentiment_analysis/README.md
+++ b/market_sentiment_analysis/README.md
@@ -1,0 +1,26 @@
+# Market Sentiment Analysis
+
+Analyzing financial news sentiment.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/market_sentiment_analysis/main.py
+++ b/market_sentiment_analysis/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Summarize current market sentiment from recent headlines."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/portfolio_optimization/README.md
+++ b/portfolio_optimization/README.md
@@ -1,0 +1,26 @@
+# Portfolio Optimization
+
+Optimizing an investment portfolio.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/portfolio_optimization/main.py
+++ b/portfolio_optimization/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Suggest an optimized asset allocation for a moderate risk profile."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/regulatory_reporting/README.md
+++ b/regulatory_reporting/README.md
@@ -1,0 +1,26 @@
+# Regulatory Reporting
+
+Summarizing compliance details for reporting.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/regulatory_reporting/main.py
+++ b/regulatory_reporting/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Generate a short regulatory compliance report summary."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)


### PR DESCRIPTION
## Summary
- provide README overview
- add 10 sample financial use cases using Autogen with Ollama
- each use case includes README and `main.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f63334fdc8331b69960ea39df1738