### PR TITLE
Add financial Autogen examples using local Ollama model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# Autogen_Agents
-Autogen_Agents
+# Autogen Agents
+
+This repository showcases 10 financial-industry examples for [Autogen](https://github.com/microsoft/autogen) connected to a locally hosted [Ollama](https://ollama.ai/) model.
+
+All code is located in the `financial_examples` folder. Each subdirectory contains a `README.md` and `main.py` describing how to run that particular scenario.
+
+See [`financial_examples/README.md`](financial_examples/README.md) for setup instructions and the list of available use cases.

--- a/financial_examples/README.md
+++ b/financial_examples/README.md
@@ -1,0 +1,40 @@
+# Financial Autogen Examples
+
+These examples demonstrate how to use [Autogen](https://github.com/microsoft/autogen) with a local model served by [Ollama](https://ollama.ai/). Follow the steps below to get started.
+
+## Setup
+
+1. Launch an Ollama server with a model:
+
+   ```bash
+   ollama serve &
+   ollama run llama2
+   ```
+
+2. Install the required package:
+
+   ```bash
+   pip install pyautogen
+   ```
+
+## Available Use Cases
+
+The `financial_examples` directory contains the following folders:
+
+- `algorithmic_trading` – Algorithmic Trading Idea Generation
+- `compliance_monitoring` – Compliance Monitoring
+- `credit_risk_assessment` – Credit Risk Assessment
+- `customer_support` – Customer Support Chatbot
+- `data_extraction` – Financial Data Extraction
+- `fraud_detection` – Fraud Detection
+- `loan_underwriting` – Loan Underwriting
+- `market_sentiment_analysis` – Market Sentiment Analysis
+- `portfolio_optimization` – Portfolio Optimization
+- `regulatory_reporting` – Regulatory Reporting
+
+Each subfolder has a `README.md` and `main.py` showing how to run the example. Run an example with:
+
+```bash
+cd <folder>
+python3 main.py
+```

--- a/financial_examples/algorithmic_trading/README.md
+++ b/financial_examples/algorithmic_trading/README.md
@@ -1,0 +1,26 @@
+# Algorithmic Trading Idea Generation
+
+Generating a basic trading strategy.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/financial_examples/algorithmic_trading/main.py
+++ b/financial_examples/algorithmic_trading/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Provide a simple momentum trading strategy idea."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/financial_examples/compliance_monitoring/README.md
+++ b/financial_examples/compliance_monitoring/README.md
@@ -1,0 +1,26 @@
+# Compliance Monitoring
+
+Monitoring trades for compliance violations.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/financial_examples/compliance_monitoring/main.py
+++ b/financial_examples/compliance_monitoring/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Check trading logs for potential compliance issues."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/financial_examples/credit_risk_assessment/README.md
+++ b/financial_examples/credit_risk_assessment/README.md
@@ -1,0 +1,26 @@
+# Credit Risk Assessment
+
+Assessing credit risk for a hypothetical borrower.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/financial_examples/credit_risk_assessment/main.py
+++ b/financial_examples/credit_risk_assessment/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Evaluate credit risk for a sample loan applicant."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/financial_examples/customer_support/README.md
+++ b/financial_examples/customer_support/README.md
@@ -1,0 +1,26 @@
+# Customer Support Chatbot
+
+Answering customer questions automatically.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/financial_examples/customer_support/main.py
+++ b/financial_examples/customer_support/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Answer common customer questions about account features."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/financial_examples/data_extraction/README.md
+++ b/financial_examples/data_extraction/README.md
@@ -1,0 +1,26 @@
+# Financial Data Extraction
+
+Extracting metrics from financial text.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/financial_examples/data_extraction/main.py
+++ b/financial_examples/data_extraction/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Extract key financial metrics from the given statement."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/financial_examples/fraud_detection/README.md
+++ b/financial_examples/fraud_detection/README.md
@@ -1,0 +1,26 @@
+# Fraud Detection
+
+Finding suspicious transactions from sample data.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/financial_examples/fraud_detection/main.py
+++ b/financial_examples/fraud_detection/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Identify potential fraud in a list of sample transactions."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/financial_examples/loan_underwriting/README.md
+++ b/financial_examples/loan_underwriting/README.md
@@ -1,0 +1,26 @@
+# Loan Underwriting
+
+Underwriting a sample loan application.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/financial_examples/loan_underwriting/main.py
+++ b/financial_examples/loan_underwriting/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Assess a loan application and provide underwriting notes."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/financial_examples/market_sentiment_analysis/README.md
+++ b/financial_examples/market_sentiment_analysis/README.md
@@ -1,0 +1,26 @@
+# Market Sentiment Analysis
+
+Analyzing financial news sentiment.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/financial_examples/market_sentiment_analysis/main.py
+++ b/financial_examples/market_sentiment_analysis/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Summarize current market sentiment from recent headlines."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/financial_examples/portfolio_optimization/README.md
+++ b/financial_examples/portfolio_optimization/README.md
@@ -1,0 +1,26 @@
+# Portfolio Optimization
+
+Optimizing an investment portfolio.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/financial_examples/portfolio_optimization/main.py
+++ b/financial_examples/portfolio_optimization/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Suggest an optimized asset allocation for a moderate risk profile."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)

--- a/financial_examples/regulatory_reporting/README.md
+++ b/financial_examples/regulatory_reporting/README.md
@@ -1,0 +1,26 @@
+# Regulatory Reporting
+
+Summarizing compliance details for reporting.
+
+This example uses the [Autogen](https://github.com/microsoft/autogen) library with a local model hosted by [Ollama](https://ollama.ai/).
+
+## Running
+
+1. Ensure an Ollama server is running with a compatible model, e.g.:
+
+```bash
+ollama serve &
+ollama run llama2
+```
+
+2. Install dependencies:
+
+```bash
+pip install pyautogen
+```
+
+3. Execute the example:
+
+```bash
+python3 main.py
+```

--- a/financial_examples/regulatory_reporting/main.py
+++ b/financial_examples/regulatory_reporting/main.py
@@ -1,0 +1,19 @@
+import autogen
+
+# Configure local LLM served by Ollama
+config_list = [
+    {
+        "model": "llama2",
+        "api_key": "ollama",
+        "base_url": "http://localhost:11434/v1",
+    }
+]
+llm_config = {"config_list": config_list}
+
+assistant = autogen.AssistantAgent(name="assistant", llm_config=llm_config)
+user_proxy = autogen.UserProxyAgent(name="user_proxy", human_input_mode="NEVER")
+
+task = "Generate a short regulatory compliance report summary."
+
+if __name__ == "__main__":
+    user_proxy.initiate_chat(assistant, message=task)


### PR DESCRIPTION
## Summary
- slim README in repo root and point to example directory
- create `financial_examples/README.md` with setup instructions
- keep 10 financial example folders one level deep with README and `main.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f63334fdc8331b69960ea39df1738